### PR TITLE
chore: Fix govulncheck vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.4 as builder
+FROM golang:1.22.2 as builder
 
 # Set the Current Working Directory inside the container
 WORKDIR /app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mimiro-io/oracle-datalayer
 
-go 1.21
+go 1.22.2
 
 require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
@@ -47,10 +47,10 @@ require (
 	go.uber.org/atomic v1.10.0 // indirect
 	go.uber.org/dig v1.15.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
-	golang.org/x/crypto v0.14.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
-	golang.org/x/text v0.13.0 // indirect
+	golang.org/x/crypto v0.21.0 // indirect
+	golang.org/x/net v0.23.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.0.0-20220920022843-2ce7c2934d45 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.14.0 h1:wBqGXzWJW6m1XrIKlAH0Hs1JJ7+9KBwnIO8v66Q9cHc=
-golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf4=
+golang.org/x/crypto v0.21.0 h1:X31++rzVUdKhX5sWmSOFZxx8UW/ldWx55cbf08iNAMA=
+golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -331,8 +331,8 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
-golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
+golang.org/x/net v0.23.0 h1:7EYJ93RZ9vYSZAIb2x3lnuvqO5zneoD6IvWjuhfxjTs=
+golang.org/x/net v0.23.0/go.mod h1:JKghWKKOSdJwpW2GEx0Ja7fmaKnMsbu+MWVZTokSYmg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -393,8 +393,8 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
-golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -402,8 +402,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
-golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=


### PR DESCRIPTION
Fixes
```
Scanning your code and 256 packages across 47 dependent modules for known vulnerabilities...

=== Symbol Results ===

Vulnerability #1: GO-2024-2687
    HTTP/2 CONTINUATION flood in net/http
  More info: https://pkg.go.dev/vuln/GO-2024-2687
  Module: golang.org/x/net
    Found in: golang.org/x/net@v0.17.0
    Fixed in: golang.org/x/net@v0.23.0
    Example traces found:
      #1: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.ConnectionError.Error
      #2: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http2.ErrCode.String
      #3: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http2.FrameHeader.String
      #4: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http2.FrameType.String
      #5: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.GoAwayError.Error
      #6: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http2.Setting.String
      #7: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http2.SettingID.String
      #8: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.StreamError.Error
      #9: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http2.chunkWriter.Write
      #10: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.connError.Error
      #11: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.duplicatePseudoHeaderError.Error
      #12: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http2.gzipReader.Close
      #13: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http2.gzipReader.Read
      #14: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.headerFieldNameError.Error
      #15: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.headerFieldValueError.Error
      #16: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http2.pseudoHeaderError.Error
      #17: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http2.stickyErrWriter.Write
      #18: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http2.transportResponseBody.Close
      #19: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http2.transportResponseBody.Read
      #20: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http2.writeData.String

  Standard library
    Found in: net/http@go1.22.1
    Fixed in: net/http@go1.22.2
    Example traces found:
      #1: internal/conf/config.go:12:32: conf.NewEnv calls os.LookupEnv, which eventually calls http.CanonicalHeaderKey
      #2: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.Client.Do
      #3: internal/web/middlewares/auth0.go:71:24: middlewares.newCache calls http.Get
      #4: internal/conf/manager.go:144:17: conf.ConfigurationManager.loadUrl calls http.Header.Add
      #5: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.Header.Del
      #6: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.Header.Get
      #7: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.Header.Set
      #8: internal/conf/manager.go:132:29: conf.ConfigurationManager.loadUrl calls http.NewRequest
      #9: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.Request.FormValue
      #10: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.Request.Referer
      #11: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.Request.UserAgent
      #12: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.body.Close
      #13: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.body.Read
      #14: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.bodyEOFSignal.Close
      #15: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.bodyEOFSignal.Read
      #16: internal/conf/config.go:60:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.bodyLocked.Read
      #17: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls multierr.multiError.Error, which eventually calls http.bufioFlushWriter.Write
      #18: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.cancelTimerBody.Close
      #19: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.cancelTimerBody.Read
      #20: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.checkConnErrorWriter.Write
      #21: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.chunkWriter.Write
      #22: internal/conf/config.go:60:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.connReader.Read
      #23: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which eventually calls http.expectContinueReader.Close
      #24: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.expectContinueReader.Read
      #25: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.gzipReader.Close
      #26: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.gzipReader.Read
      #27: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2ConnectionError.Error
      #28: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2ErrCode.String
      #29: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2FrameHeader.String
      #30: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2FrameType.String
      #31: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2FrameWriteRequest.String
      #32: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2GoAwayError.Error
      #33: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2Setting.String
      #34: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2SettingID.String
      #35: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2StreamError.Error
      #36: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.http2chunkWriter.Write
      #37: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2connError.Error
      #38: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2duplicatePseudoHeaderError.Error
      #39: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.http2gzipReader.Close
      #40: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.http2gzipReader.Read
      #41: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2headerFieldNameError.Error
      #42: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2headerFieldValueError.Error
      #43: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.http2pseudoHeaderError.Error
      #44: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which eventually calls http.http2requestBody.Close
      #45: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.http2requestBody.Read
      #46: internal/web/datasethandler.go:162:22: web.getChangesHandler calls echo.Response.Flush, which calls http.http2responseWriter.Flush
      #47: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which calls http.http2responseWriter.Write
      #48: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.http2responseWriter.WriteHeader
      #49: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls multierr.multiError.Error, which eventually calls http.http2responseWriter.WriteString
      #50: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.http2stickyErrWriter.Write
      #51: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which calls http.http2transportResponseBody.Close
      #52: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.http2transportResponseBody.Read
      #53: internal/layers/postlayer.go:71:32: layers.PostLayer.PostEntities calls fmt.Sprintf, which eventually calls http.http2writeData.String
      #54: internal/conf/config.go:60:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.loggingConn.Read
      #55: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.loggingConn.Write
      #56: internal/conf/config.go:60:27: conf.parseEnv calls viper.ReadInConfig, which eventually calls http.maxBytesReader.Read
      #57: internal/conf/config.go:12:32: conf.NewEnv calls os.LookupEnv, which eventually calls http.onceCloseListener.Close
      #58: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.persistConn.Read
      #59: internal/conf/manager.go:71:17: conf.ConfigurationManager.Init calls jobrunner.Start, which eventually calls http.persistConnWriter.Write
      #60: internal/conf/manager.go:147:24: conf.ConfigurationManager.loadUrl calls httpclient.Client.Do, which eventually calls http.readTrackingBody.Close
      #61: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.readTrackingBody.Read
      #62: internal/conf/manager.go:156:24: conf.ConfigurationManager.loadUrl calls ioutil.ReadAll, which eventually calls http.readWriteCloserBody.Read
      #63: internal/web/datasethandler.go:162:22: web.getChangesHandler calls echo.Response.Flush, which calls http.response.Flush
      #64: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which calls http.response.Write
      #65: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.response.WriteHeader
      #66: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls multierr.multiError.Error, which eventually calls http.response.WriteString
      #67: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which calls http.timeoutWriter.Write
      #68: internal/web/datasethandler.go:160:22: web.getChangesHandler calls echo.Response.Write, which eventually calls http.timeoutWriter.WriteHeader
      #69: internal/conf/manager.go:90:77: conf.ConfigurationManager.load calls http.transportReadFromServerError.Error

Your code is affected by 1 vulnerability from the Go standard library.
```