### PR TITLE
chore: fix FromAsCasing warnings when building docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5 as build_base
+FROM golang:1.22.5 AS build_base
 
 # Set the Current Working Directory inside the container
 WORKDIR /app
@@ -9,7 +9,7 @@ COPY go.mod go.sum ./
 # Download all dependencies. Dependencies will be cached if the go.mod and go.sum files are not changed
 RUN go mod download
 
-FROM  build_base as builder
+FROM  build_base AS builder
 # Copy the source from the current directory to the Working Directory inside the container
 COPY . .
 


### PR DESCRIPTION
Since recent Docker versions [run build checks by default](https://docs.docker.com/build/checks/#build-with-checks) when building, we should fix this annoying warning when building the docker container

```
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)                                                                                                          0.0s
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 12)                                                                                                         0.0s
```